### PR TITLE
Renaming the Message model to Note

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,6 +304,8 @@ GEM
     stimulus-rails (1.3.0)
       railties (>= 6.0.0)
     stringio (3.1.0)
+    tailwindcss-rails (2.0.32-arm64-darwin)
+      railties (>= 6.0.0)
     tailwindcss-rails (2.0.32-x86_64-linux)
       railties (>= 6.0.0)
     thor (1.3.0)
@@ -326,6 +328,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,3 @@
 class ApplicationController < ActionController::Base
-  include Authenticated
+  include Authenticate
 end

--- a/app/controllers/concerns/authenticate.rb
+++ b/app/controllers/concerns/authenticate.rb
@@ -1,4 +1,4 @@
-module Authenticated
+module Authenticate
   extend ActiveSupport::Concern
 
   included do


### PR DESCRIPTION
I want us to have a different foundation for the Message model so I'm renaming yours to Note so that I can use this name. I mentioned it in one of the cards, but I want our internal modeling to match OpenAI's as much as possible so we don't have name & field mismatches between the API interrogation and our internal API.