### PR TITLE
Switches to the headless chrome driver

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,5 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
 end


### PR DESCRIPTION
This prevents the browser from stealing focus from your editor/terminal when running integration tests.

Once in a while I'm sure it's helpful to have this jump into the foreground but for day to day use I think it's better to have it in the background.