### PR TITLE
Removes username and password for dev db

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -15,9 +15,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  user: postgres
   host: localhost
-  password: mysecretpassword 
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:


### PR DESCRIPTION
This is a bit chaotic of a change, but I think it's worth it. Let me know what you think.

On a mac when you install postgres (`brew install postgres`) it creates a user login for the current user and a database for that user. It configures the system to trust the current user to login to postgres without a password _because the user has already logged into the system_.

On linux this configuration is almost exactly the same. The database will already trust pg users logging in with system users which name matches, but by default there is no user created. (At least this is true for the debian/ubuntu postgres install.) This is easily remidied by running: `createuser --createdb $(whoami)`.

Before this change, the configuration requires that everyone create a login to their local postgres with a password that matches this project password.

After this change, anyone with a properly set up local database can connect without any manual setup.

After this is merged, local development servers will need to be rebooted and `bin/rails db:reset` will need to be run again.