### PR TITLE
Creates RUN_SOLID_QUEUE_IN_PUMA env var

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -33,3 +33,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
+
+if ENV.fetch("RUN_SOLID_QUEUE_IN_PUMA") { false }
+  plugin :solid_queue
+end

--- a/render.yaml
+++ b/render.yaml
@@ -11,20 +11,6 @@ envVarGroups:
       generateValue: true
 
 services:
-  - type: worker
-    name: soliqueue-worker
-    runtime: ruby
-    plan: free
-    buildCommand: bundle install
-    startCommand: ./bin/rake solid_queue:start 
-    envVars:
-      - key: DATABASE_URL
-        fromDatabase:
-          name: hostedgpt
-          property: connectionString
-      - fromGroup: hostedgpt-secrets
-      - key: WEB_CONCURRENCY
-        value: 2 # sensible default
   - type: web
     name: hostedgpt
     runtime: ruby
@@ -38,5 +24,7 @@ services:
           name: hostedgpt
           property: connectionString
       - fromGroup: hostedgpt-secrets
+      - key: RUN_SOLID_QUEUE_IN_PUMA
+        value: true
       - key: WEB_CONCURRENCY
         value: 2 # sensible default


### PR DESCRIPTION
Set RUN_SOLID_QUEUE_IN_PUMA to any value to cause solid queue to run within puma. In render.yaml, the default is to enable the in-puma queue worker.

This is helpful in settings where puma load is low, and running a dedicated worker is unnecessary.

fixes #63 