### PR TITLE
Formats toast messages so they don't break the page layouts

### DIFF
--- a/app/javascript/controllers/click_toggle_controller.js
+++ b/app/javascript/controllers/click_toggle_controller.js
@@ -3,7 +3,7 @@ import { Controller } from '@hotwired/stimulus'
 // This controller listens for a click on the "trigger" element. When it receives one, it toggles the "flippable" class on the "destination" element:
 //
 // The same element where you are defining the controller must get data-click-toggle-flippable-class="..class(es) named here..."
-// Any two elements at the same level as the controller or below get data-click-toggle-target="destination" and data-click-toggle-target="target"
+// Any two elements at the same level as the controller or below get data-click-toggle-target="destination" and data-click-toggle-target="trigger"
 
 export default class extends Controller {
   static classes = [ "flippable" ]

--- a/app/views/layouts/_toast.html.erb
+++ b/app/views/layouts/_toast.html.erb
@@ -1,0 +1,31 @@
+<% if flash.any? %>
+  <div class="fixed top-4 left-[50%] translate-x-[-50%] w-full sm:w-1/2
+              flex flex-col gap-4 items-center
+              z-10
+              ">
+      <% flash.each do |type, text| %>
+        <%
+          toast_classes = case type
+                         when "notice"
+                           "bg-blue-100 text-blue-900 border-blue-400"
+                         when "alert"
+                           "bg-red-100 text-red-900 border-red-400"
+                         end
+        %>
+      <div
+          class="<%= toast_classes %> flex justify-between gap-4 rounded border items-baseline w-full pl-4"
+          data-controller="click-toggle"
+          data-click-toggle-flippable-class="hidden"
+          data-click-toggle-target="destination"
+      >
+          <p><%= text %></p>
+          <a href="#"
+              class="p-4"
+              data-action="click-toggle#handleEvent:prevent"
+          >
+          &times;
+          </a>
+        </div>
+      <% end %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,12 +14,7 @@
     <%= content_for :head %>
   </head>
   <body class="font-sans">
-    <% if alert.present? %>
-      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
-    <% end %>
-    <% if notice.present? %>
-      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
-    <% end %>
     <%= yield %>
+    <%= render "layouts/toast" %>
   </body>
 </html>


### PR DESCRIPTION
fixes #75 

<img width="499" alt="image" src="https://github.com/hostedgpt/hostedgpt/assets/208647/5cdc46eb-f091-4ca7-833f-03fe2d16eb20">

<img width="851" alt="image" src="https://github.com/hostedgpt/hostedgpt/assets/208647/930491d5-e679-4407-a2b1-169d0a09784a">
