### PR TITLE
Restructure routes for cleaner new conversations

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,7 +1,7 @@
 class MessagesController < ApplicationController
   skip_before_action :authenticate_user!
-  before_action :set_assistant, only: [:new, :create]
   before_action :set_conversation, only: [:index]
+  before_action :set_assistant, only: [:index, :new, :create]
   before_action :set_message, only: [:show, :edit, :update, :destroy]
 
   def index
@@ -45,12 +45,13 @@ class MessagesController < ApplicationController
 
   private
 
-  def set_assistant
-    @assistant = Current.user.assistants.find(params[:assistant_id])
-  end
-
   def set_conversation
     @conversation = Current.user.conversations.find(params[:conversation_id])
+  end
+
+  def set_assistant
+    @assistant = Current.user.assistants.find_by(id: params[:assistant_id])
+    @assistant ||= @conversation.assistant
   end
 
   def set_message

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,6 +1,6 @@
 class MessagesController < ApplicationController
   skip_before_action :authenticate_user!
-  before_action :set_current_assistant, only: [:new, :create]
+  before_action :set_assistant, only: [:new, :create]
   before_action :set_conversation, only: [:index]
   before_action :set_message, only: [:show, :edit, :update, :destroy]
 
@@ -12,14 +12,14 @@ class MessagesController < ApplicationController
   end
 
   def new
-    @message = Current.assistant.messages.new
+    @message = @assistant.messages.new
   end
 
   def edit
   end
 
   def create
-    @message = Message.new(message_params)
+    @message = @assistant.messages.new(message_params)
 
     if @message.save
       redirect_to @message, notice: "Message was successfully created."
@@ -45,8 +45,8 @@ class MessagesController < ApplicationController
 
   private
 
-  def set_current_assistant
-    Current.assistant = Current.user.assistants.find(params[:assistant_id])
+  def set_assistant
+    @assistant = Current.user.assistants.find(params[:assistant_id])
   end
 
   def set_conversation

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,6 +1,7 @@
 class MessagesController < ApplicationController
   skip_before_action :authenticate_user!
-  before_action :set_conversation, only: [:index, :new, :create]
+  before_action :set_current_assistant, only: [:new, :create]
+  before_action :set_conversation, only: [:index]
   before_action :set_message, only: [:show, :edit, :update, :destroy]
 
   def index
@@ -11,18 +12,17 @@ class MessagesController < ApplicationController
   end
 
   def new
-    @message = @conversation.messages.build
+    @message = Current.assistant.messages.new
   end
 
   def edit
   end
 
   def create
-    @message = @conversation.messages.build(message_params)
-    @message.role = :user
+    @message = Message.new(message_params)
 
     if @message.save
-      redirect_to @message.conversation, notice: "Message was successfully created."
+      redirect_to @message, notice: "Message was successfully created."
     else
       render :new, status: :unprocessable_entity
     end
@@ -42,7 +42,12 @@ class MessagesController < ApplicationController
     redirect_to conversation_messages_url(@conversation), notice: "Message was successfully destroyed.", status: :see_other
   end
 
+
   private
+
+  def set_current_assistant
+    Current.assistant = Current.user.assistants.find(params[:assistant_id])
+  end
 
   def set_conversation
     @conversation = Current.user.conversations.find(params[:conversation_id])
@@ -53,6 +58,6 @@ class MessagesController < ApplicationController
   end
 
   def message_params
-    params.require(:message).permit(:content_text)
+    params.require(:message).permit(:conversation_id, :content_text)
   end
 end

--- a/app/models/assistant.rb
+++ b/app/models/assistant.rb
@@ -5,7 +5,7 @@ class Assistant < ApplicationRecord
   has_many :documents, dependent: :destroy
   has_many :runs, dependent: :destroy
   has_many :steps, dependent: :destroy
-  has_many :messages, through: :conversations
+  has_many :messages
 
   validates :tools, presence: true, allow_blank: true
 end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,4 +1,3 @@
 class Current < ActiveSupport::CurrentAttributes
   attribute :user
-  attribute :assistant
 end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,3 +1,4 @@
 class Current < ActiveSupport::CurrentAttributes
   attribute :user
+  attribute :assistant
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,6 +1,6 @@
 class Message < ApplicationRecord
+  belongs_to :assistant
   belongs_to :conversation
-  delegate :assistant, to: :conversation
   belongs_to :content_document, class_name: "Document", optional: true
   belongs_to :run, optional: true
 
@@ -20,7 +20,7 @@ class Message < ApplicationRecord
   private
 
   def create_conversation
-    self.conversation = Conversation.create!(user: Current.user, assistant: Current.assistant)
+    self.conversation = Conversation.create!(user: Current.user, assistant: assistant)
   end
 
   def set_default_role

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -8,10 +8,26 @@ class Message < ApplicationRecord
 
   enum role: %w[user assistant].index_by(&:to_sym)
 
-  validates :run, presence: true, if: -> { assistant? }
-  validates :role, presence: true
+  before_validation :set_default_role, on: :create
+  before_validation :create_conversation, on: :create, if: -> { conversation.blank? }
 
-  after_create_commit -> {
-    broadcast_append_to conversation, partial: "messages/message", locals: {scroll_into_view: true, conversation: conversation}
-  }
+  validates :content_text, :role, presence: true
+  validates :run, presence: true, if: -> { assistant? }
+
+  after_create_commit :broadcast_message
+
+
+  private
+
+  def create_conversation
+    self.conversation = Conversation.create!(user: Current.user, assistant: Current.assistant)
+  end
+
+  def set_default_role
+    self.role ||= :user
+  end
+
+  def broadcast_message
+    broadcast_append_to conversation, partial: "messages/message", locals: { scroll_into_view: true, conversation: conversation }
+  end
 end

--- a/app/views/messages/_new_form.html.erb
+++ b/app/views/messages/_new_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: [Current.assistant, message], class: "contents") do |form| %>
+<%= form_with(model: [assistant, message], class: "contents") do |form| %>
   <% if message.errors.any? %>
     <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
       <h2><%= pluralize(message.errors.count, "error") %> prohibited this message from being saved:</h2>

--- a/app/views/messages/_new_form.html.erb
+++ b/app/views/messages/_new_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: [message.conversation, message], class: "contents") do |form| %>
+<%= form_with(model: [Current.assistant, message], class: "contents") do |form| %>
   <% if message.errors.any? %>
     <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
       <h2><%= pluralize(message.errors.count, "error") %> prohibited this message from being saved:</h2>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -5,7 +5,7 @@
 
   <div class="flex justify-between items-center">
     <h1 class="font-bold text-4xl">Messages</h1>
-    <%= link_to "New message", new_conversation_message_path(@conversation), class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
+    <%= link_to "New message", new_assistant_message_path(@conversation.assistant), class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
   </div>
 
   <div id="messages" class="min-w-full">

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
   <h1 class="font-bold text-4xl">New message</h1>
 
-  <%= render "new_form", message: @message %>
+  <%= render "new_form", assistant: @assistant, message: @message %>
 </div>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -2,6 +2,4 @@
   <h1 class="font-bold text-4xl">New message</h1>
 
   <%= render "new_form", message: @message %>
-
-  <%= link_to "Back to messages", conversation_messages_path(@conversation), class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,14 +2,14 @@ Rails.application.routes.draw do
   resources :assistants do
     get :instructions, to: "assistants/instructions#edit"
     patch :instructions, to: "assistants/instructions#update"
+    resources :messages, only: [:new, :create]
   end
 
-  shallow do
-    resources :conversations do
-      resources :messages
-    end
+  resources :conversations do
+    resources :messages, only: :index
   end
 
+  resources :messages, except: [:new, :create, :index]
   resources :documents
 
   resources :users, only: [:new, :create, :update]

--- a/db/migrate/20240128211647_add_assistant_id_to_messages.rb
+++ b/db/migrate/20240128211647_add_assistant_id_to_messages.rb
@@ -1,0 +1,5 @@
+class AddAssistantIdToMessages < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :messages, :assistant, null: true, foreign_key: true
+  end
+end

--- a/db/migrate/20240128211815_change_column_assistant_id_on_messages.rb
+++ b/db/migrate/20240128211815_change_column_assistant_id_on_messages.rb
@@ -1,0 +1,10 @@
+class ChangeColumnAssistantIdOnMessages < ActiveRecord::Migration[7.1]
+  def up
+    Message.all.each { |m| m.update!(assistant: m.conversation.assistant) }
+    change_column :messages, :assistant_id, :bigint, null: false
+  end
+
+  def down
+    change_column :messages, :assistant_id, :bigint, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_10_111346) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_28_211815) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -102,6 +102,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_10_111346) do
     t.datetime "updated_at", null: false
     t.bigint "content_document_id"
     t.bigint "run_id"
+    t.bigint "assistant_id", null: false
+    t.index ["assistant_id"], name: "index_messages_on_assistant_id"
     t.index ["content_document_id"], name: "index_messages_on_content_document_id"
     t.index ["conversation_id"], name: "index_messages_on_conversation_id"
     t.index ["run_id"], name: "index_messages_on_run_id"
@@ -304,6 +306,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_10_111346) do
   add_foreign_key "documents", "assistants"
   add_foreign_key "documents", "messages"
   add_foreign_key "documents", "users"
+  add_foreign_key "messages", "assistants"
   add_foreign_key "messages", "conversations"
   add_foreign_key "messages", "documents", column: "content_document_id"
   add_foreign_key "messages", "runs"

--- a/test/fixtures/messages.yml
+++ b/test/fixtures/messages.yml
@@ -1,4 +1,5 @@
 hear_me:
+  assistant: samantha
   conversation: greeting
   role: user
   content_text: Can you hear me?
@@ -6,6 +7,7 @@ hear_me:
   run:
 
 yes_i_do:
+  assistant: samantha
   conversation: greeting
   role: assistant
   content_text: Yes, I can hear you. How can I help you today?
@@ -13,6 +15,7 @@ yes_i_do:
   run: hear_me_response
 
 identify_photo:
+  assistant: samantha
   conversation: greeting
   role: user
   content_text: What do you see in this photo?
@@ -20,6 +23,7 @@ identify_photo:
   run:
 
 photo_identified:
+  assistant: samantha
   conversation: greeting
   role: assistant
   content_text: That looks like a cat.

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -33,10 +33,9 @@ class MessageTest < ActiveSupport::TestCase
 
   test "minimal create works when Current is set" do
     Current.user = users(:keith)
-    Current.assistant = assistants(:samantha)
 
     assert_nothing_raised do
-      Message.create!(content_text: "Hello")
+      Message.create!(assistant: assistants(:samantha), content_text: "Hello")
     end
 
     assert_equal assistants(:samantha), Message.last.assistant
@@ -46,6 +45,7 @@ class MessageTest < ActiveSupport::TestCase
 
   test "creating an assistant message requires a run to be associated" do
     m = Message.new(
+      assistant: assistants(:samantha),
       conversation: conversations(:greeting),
       role: :assistant,
       content_text: "I am here."
@@ -69,7 +69,12 @@ class MessageTest < ActiveSupport::TestCase
   end
 
   test "creating a message sends a turbo broadcast" do
-    message = Message.create!(conversation: conversations(:greeting), role: "user", content_text: "test message")
+    message = Message.create!(
+      assistant: assistants(:samantha),
+      conversation: conversations(:greeting),
+      role: :user,
+      content_text: "test message"
+    )
     assert_turbo_stream_broadcasts conversations(:greeting)
     broadcasts = capture_turbo_stream_broadcasts conversations(:greeting)
     assert_equal 1, broadcasts.length

--- a/test/system/conversations_test.rb
+++ b/test/system/conversations_test.rb
@@ -25,7 +25,7 @@ class ConversationsTest < ApplicationSystemTestCase
   test "when a message arrives while viewing the conversation, it is displayed" do
     visit conversation_url(@conversation)
     message_text = "Hello! #{Time.now}"
-    @conversation.messages.create! content_text: message_text, role: :user
+    @conversation.messages.create! assistant: @conversation.assistant, content_text: message_text, role: :user
     assert_text message_text
   end
 end


### PR DESCRIPTION
For #87 

Move messages#new and messages#create to be nested under /assistants rather than conversations. This is so that we can present users with a new message form without having to pre-create the conversation.

This also does work deep in the model so that when a new message is being created, if a conversation_id wasn't provided then it pre-creates the conversation. In order for this to be clean, this PR also **adds assistant_id as an attribute of the Message model**.

I'm preparing for a user experience where you can start a new conversation at this route:
http://localhost:3000/assistants/630504688/messages/new

After you submit the first chat message you'll be redirected to this route. A Message and Conversation object were created together:
http://localhost:3000/conversations/115582124

Rails Turbo will make this nice and fast so the user won't even notice. This will support cleaner models and controllers.

(I've already started the other front-end refactor of views to make this all work but I'm breaking the route refactor into it's own PR for easier review.)