### PR TITLE
Fix back-button history for turbo-frames

### DIFF
--- a/app/javascript/controllers/turbo_frame_history_controller.js
+++ b/app/javascript/controllers/turbo_frame_history_controller.js
@@ -1,0 +1,39 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+
+  connect() {
+    document.addEventListener('turbo:before-fetch-request', this.beforeFetchRequest)
+    window.addEventListener("popstate", this.popState)
+  }
+
+  disconnect() {
+    document.removeEventListener('turbo:before-fetch-request', this.beforeFetchRequest)
+    window.removeEventListener("popstate", this.popState)
+  }
+
+  beforeFetchRequest(event) {
+    // Solution from: https://github.com/hotwired/turbo/issues/792
+    // When we do a fetch request that targets a turbo-frame, we manually update the URL by
+    // adding to pushState. When we do, we set a special param (refresh_on_back = true). We
+    // then monitor popState event, which fires every time the back button is pressed. In those
+    // cases we do a new Turbo visit to manually refresh the page.
+    //
+    // This "fixes" history state for turbo frames, but it doesn't use the Turbo page cache.
+    // This simply means that going back will cuase a new server request, but that's okay for our
+    // purposes.
+    let fetchTargetingFrame = (event.detail.fetchOptions.headers['Turbo-Frame'] != undefined)
+
+    if (fetchTargetingFrame) {
+      Turbo.cache.exemptPageFromPreview()
+      history.replaceState({page: document.title, refresh_on_back: true}, '', window.location.pathname);
+      history.pushState({page: 'new title', refresh_on_back: true}, '', event.detail.url.pathname) // not sure how to get page title
+    }
+  }
+
+  popState(event) {
+    if (event.state && event.state.refresh_on_back) {
+      Turbo.visit(window.location.href, { action: "replace" })
+    }
+  }
+}

--- a/app/views/shared/_two_columns.html.erb
+++ b/app/views/shared/_two_columns.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_stream_from @conversation %>
 
 <div class="flex h-screen"
-    data-controller="click-toggle"
+    data-controller="click-toggle turbo-frame-history"
     data-click-toggle-flippable-class="!hidden"
 >
 


### PR DESCRIPTION
There is an issue with turbo-frame elements where you can target them to be updated while preserving the overall page state, but the URL does not change to reflect this and the browse back button does not work. This may be intended behavior or it may be a bug with Turbo, I can't tell. I have an open issue with them here: https://github.com/hotwired/turbo/issues/1156

But regardless, we want it to work because clicking a conversation in the left sidebar refreshes the turbo-frame id="conversation" in the right side. We do the frame refreshing because we want the scroll position of the left side to remain preserved.

This works by manually updating the browser's pushState and manually handling the back button for these cases. Demo here: https://share.zight.com/jku8YrZLj