### PR TITLE
Rename sorted scope to "ordered"

### DIFF
--- a/app/controllers/assistants_controller.rb
+++ b/app/controllers/assistants_controller.rb
@@ -2,7 +2,7 @@ class AssistantsController < ApplicationController
   before_action :set_assistant, only: [:show, :edit, :update, :destroy]
 
   def index
-    assistant = Current.user.assistants.sorted.first
+    assistant = Current.user.assistants.ordered.first
     redirect_to new_assistant_message_path(assistant)
   end
 

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -44,7 +44,7 @@ class ConversationsController < ApplicationController
   end
 
   def set_sidebar_assistants
-    @sidebar_assistants = Current.user.assistants.sorted
+    @sidebar_assistants = Current.user.assistants.ordered
   end
 
   def set_conversation

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -6,7 +6,7 @@ class MessagesController < ApplicationController
   before_action :set_sidebar_assistants, only: [:index, :new]
 
   def index
-    @messages = @conversation.messages.sorted
+    @messages = @conversation.messages.ordered
     @new_message = @assistant.messages.new(conversation: @conversation)
   end
 
@@ -72,7 +72,7 @@ class MessagesController < ApplicationController
   end
 
   def set_sidebar_assistants
-    @sidebar_assistants = Current.user.assistants.sorted
+    @sidebar_assistants = Current.user.assistants.ordered
   end
 
   def message_params

--- a/app/jobs/autotitle_conversation_job.rb
+++ b/app/jobs/autotitle_conversation_job.rb
@@ -10,7 +10,7 @@ class AutotitleConversationJob < ApplicationJob
     conversation = Conversation.find(conversation_id)
     Current.user = conversation.user
 
-    messages = conversation.messages.sorted.limit(4)
+    messages = conversation.messages.ordered.limit(4)
     raise ConverstionNotReady  if messages.empty?
 
     new_title = generate_title_for(messages.map(&:content_text).join("\n"))

--- a/app/models/assistant.rb
+++ b/app/models/assistant.rb
@@ -9,5 +9,5 @@ class Assistant < ApplicationRecord
 
   validates :tools, presence: true, allow_blank: true
 
-  scope :sorted, -> { order(:id) }
+  scope :ordered, -> { order(:id) }
 end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -8,7 +8,7 @@ class Conversation < ApplicationRecord
 
   after_update_commit :set_title_async, if: -> { title.blank? && messages.count >= 2 }
 
-  scope :sorted, -> { order(updated_at: :desc) }
+  scope :ordered, -> { order(updated_at: :desc) }
 
   broadcasts_refreshes
 
@@ -25,7 +25,7 @@ class Conversation < ApplicationRecord
   #  "Older" => relation
   # }
   def self.grouped_by_increasing_time_interval_for_user(user)
-    sidebar_conversations = user.conversations.sorted
+    sidebar_conversations = user.conversations.ordered
 
     keys = ["Today", "Yesterday", "This Week", "This Month", "Last Month", "Older"]
     values = [

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -17,7 +17,7 @@ class Message < ApplicationRecord
   validates :content_text, presence: true, unless: :assistant?
   validate :validate_conversation_user, if: -> { conversation.present? && Current.user }
 
-  scope :sorted, -> { order(:created_at) }
+  scope :ordered, -> { order(:created_at) }
 
   after_create_commit :broadcast_message
 

--- a/app/services/a_i_backends/open_a_i.rb
+++ b/app/services/a_i_backends/open_a_i.rb
@@ -43,7 +43,7 @@ class AIBackends::OpenAI
   private
 
   def existing_messages
-    @conversation.messages.sorted.collect do |message|
+    @conversation.messages.ordered.collect do |message|
       if @assistant.images && message.documents.present?
 
         content = [{ type: "text", text: message.content_text }]

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -8,7 +8,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   fixtures :all
 
   def login_as(user, password = "secret")
-    assistant = user.assistants.sorted.first
+    assistant = user.assistants.ordered.first
 
     visit logout_path
     assert_current_path login_path, wait: 2

--- a/test/controllers/assistants_controller_test.rb
+++ b/test/controllers/assistants_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class AssistantsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:keith)
-    @assistant = @user.assistants.sorted.first
+    @assistant = @user.assistants.ordered.first
     login_as @user
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -41,7 +41,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     user = Person.find_by(email: email).user
     assert_equal 2, user.assistants.count
 
-    assistant = user.assistants.sorted.first
+    assistant = user.assistants.ordered.first
 
     follow_redirect!
     assert_redirected_to new_assistant_message_path(assistant)

--- a/test/jobs/autotitle_conversation_job_test.rb
+++ b/test/jobs/autotitle_conversation_job_test.rb
@@ -13,7 +13,7 @@ class AutotitleConversationJobTest < ActiveJob::TestCase
 
   test "sets conversation title automatically even if there is only one message" do
     conversation = conversations(:javascript)
-    conversation.messages.sorted.last.destroy!
+    conversation.messages.ordered.last.destroy!
 
     ChatCompletionAPI.stub :get_next_response, {"topic" => "Javascript popState"} do
       AutotitleConversationJob.perform_now(conversation.id)

--- a/test/jobs/gen_next_a_i_message_job_test.rb
+++ b/test/jobs/gen_next_a_i_message_job_test.rb
@@ -10,6 +10,6 @@ class GetNextAIMessageJobTest < ActiveJob::TestCase
     end
 
     message_text = @test_client.chat.dig("choices", 0, "message", "content")
-    assert_equal message_text, @conversation.messages.sorted.last.content_text
+    assert_equal message_text, @conversation.messages.ordered.last.content_text
   end
 end

--- a/test/services/a_i_backends/open_a_i_test.rb
+++ b/test/services/a_i_backends/open_a_i_test.rb
@@ -21,7 +21,7 @@ module AIBackends
 
       assert_equal @conversation.messages.length, existing_messages.length
 
-      @conversation.messages.sorted.each_with_index do |message, i|
+      @conversation.messages.ordered.each_with_index do |message, i|
         if message.documents.present?
           assert_instance_of Array, existing_messages[i][:content]
           assert_equal message.documents.length+1, existing_messages[i][:content].length

--- a/test/system/messages/composer_test.rb
+++ b/test/system/messages/composer_test.rb
@@ -42,7 +42,7 @@ class MessagesComposerTest < ApplicationSystemTestCase
     click_element @submit
     sleep 0.3
 
-    assert_equal conversation_messages_path(@user.conversations.sorted.first), current_path, "Should have redirected to newly created conversation"
+    assert_equal conversation_messages_path(@user.conversations.ordered.first), current_path, "Should have redirected to newly created conversation"
     assert @input.value.blank?
   end
 
@@ -58,7 +58,7 @@ class MessagesComposerTest < ApplicationSystemTestCase
     send_keys "enter"
     sleep 0.3
 
-    assert_equal conversation_messages_path(@user.conversations.sorted.first), current_path, "Should have redirected to newly created conversation"
+    assert_equal conversation_messages_path(@user.conversations.ordered.first), current_path, "Should have redirected to newly created conversation"
     assert @input.value.blank?
   end
 
@@ -74,7 +74,7 @@ class MessagesComposerTest < ApplicationSystemTestCase
     send_keys "enter"
     sleep 0.3
 
-    assert_equal conversation_messages_path(@user.conversations.sorted.first), current_path, "Should have redirected to newly created conversation"
+    assert_equal conversation_messages_path(@user.conversations.ordered.first), current_path, "Should have redirected to newly created conversation"
     assert @input.value.blank?
   end
 

--- a/test/system/messages/sidebar_test.rb
+++ b/test/system/messages/sidebar_test.rb
@@ -7,7 +7,7 @@ class MessagesSidebarTest < ApplicationSystemTestCase
   end
 
   test "clicking conversations in the left side updates the right column, the path, and back button works as expected" do
-    assistant = @user.assistants.sorted.first
+    assistant = @user.assistants.ordered.first
 
     visit root_url
 
@@ -17,29 +17,29 @@ class MessagesSidebarTest < ApplicationSystemTestCase
     click_text conversations(:greeting).title
     assert_current_path conversation_messages_path(conversations(:greeting))
     assert_selected_assistant conversations(:greeting).assistant
-    assert_first_message conversations(:greeting).messages.sorted.first
+    assert_first_message conversations(:greeting).messages.ordered.first
 
     click_text conversations(:javascript).title
     assert_current_path conversation_messages_path(conversations(:javascript))
     assert_selected_assistant conversations(:javascript).assistant
-    assert_first_message conversations(:javascript).messages.sorted.first
+    assert_first_message conversations(:javascript).messages.ordered.first
 
     click_text conversations(:ruby_version).title
     assert_current_path conversation_messages_path(conversations(:ruby_version))
     assert_selected_assistant conversations(:ruby_version).assistant
-    assert_first_message conversations(:ruby_version).messages.sorted.first
+    assert_first_message conversations(:ruby_version).messages.ordered.first
 
     page.go_back
     sleep 1
     assert_current_path conversation_messages_path(conversations(:javascript))
     assert_selected_assistant conversations(:javascript).assistant
-    assert_first_message conversations(:javascript).messages.sorted.first
+    assert_first_message conversations(:javascript).messages.ordered.first
 
     page.go_back
     sleep 1
     assert_current_path conversation_messages_path(conversations(:greeting))
     assert_selected_assistant conversations(:greeting).assistant
-    assert_first_message conversations(:greeting).messages.sorted.first
+    assert_first_message conversations(:greeting).messages.ordered.first
 
     # TODO: There is a bug with the latest turbo where the final back doesn't properly load from cache.
     #
@@ -120,11 +120,11 @@ class MessagesSidebarTest < ApplicationSystemTestCase
     visit conversation_path
     assert_current_path conversation_path
 
-    assistant1 = @user.assistants.sorted.first
+    assistant1 = @user.assistants.ordered.first
     click_text assistant1.name, match: :first
     assert_current_path new_assistant_message_path(assistant1)
 
-    assistant2 = @user.assistants.sorted.second
+    assistant2 = @user.assistants.ordered.second
     second_assistant_container = all("#assistants [data-role='assistant']", visible: :false)[1]
     second_assistant_container.hover
     pencil_on_second_assistant = all("#assistants a[data-role='pencil']", visible: :false)[1]

--- a/test/system/messages_test.rb
+++ b/test/system/messages_test.rb
@@ -7,12 +7,12 @@ class MessagesTest < ApplicationSystemTestCase
   end
 
   test "after logging in, the user is redirected to the right path" do
-    assistant = @user.assistants.sorted.first
+    assistant = @user.assistants.ordered.first
     assert_current_path new_assistant_message_path(assistant)
   end
 
   test "visiting the index defaults to GPT-4 and starts a new conversation" do
-    assistant = @user.assistants.sorted.first
+    assistant = @user.assistants.ordered.first
 
     visit root_url
 


### PR DESCRIPTION
In console, a few times I've typed .ordered instead of .sorted. It feels more intuitive since it's a conjugation (am I using that word correctly) of `order`. Just doing a simple find & replace.